### PR TITLE
#57: Record recent polls in a ring buffer for introspection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ jupyter notebook src/mood-model/m0_calibration.ipynb
 - `ewma.py` — `EWMA(alpha)` accumulator with snap-on-first-update and `reset()`
 - `color.py` — `mood_to_rgb(v, e)` → `(r, g, b)` via synaesthesia profile; `apply_confidence(rgb, c)` scales saturation
 - `mood_engine.py` — `MoodEngine(bundle, artist_bundle).update(track_pairs)` → 3 RGB tuples; two-tier lookup (track → artist fallback); confidence scalar applied to saturation; now-pixel persistence across miss polls; `snapshot()` / `last_poll_outcomes()` / `OUTCOME_FIELDS` expose internal state for HTTP introspection
-- `runtime_state.py` — `RuntimeState` shared object passed from `main.py` (writer) to `ConfigServer` (reader) so introspection endpoints (#58) can read engine + last-poll metadata without circular imports; `snapshot()` returns a JSON-serializable view
+- `runtime_state.py` — `RuntimeState` shared object passed from `main.py` (writer) to `ConfigServer` (reader) so introspection endpoints (#58) can read engine + last-poll metadata without circular imports; `snapshot()` returns a JSON-serializable view; also holds the rolling 20-entry poll log (#57) — `record_poll()` appends one capped, JSON-able record per poll and `poll_log_snapshot()` returns a deep copy for `/poll-log`
 - `miss_log.py` — rolling 1000-entry miss log on flash (`misses.txt`); `append(track_id)`, `all()`, `clear()`
 - `poller.py` — poll timing with exponential back-off; `should_poll()`, `on_success()`, `on_error()`
 - `synaesthesia.py` — colour profile loader (see below)

--- a/src/musical-mood-ring/main.py
+++ b/src/musical-mood-ring/main.py
@@ -138,6 +138,12 @@ def main():
 
         # ── Poll ──────────────────────────────────────────────────────────
         if error_mode is None and config.SPOTIFY_REFRESH_TOKEN and poller.should_poll(now_ms):
+            # Per-poll outcome captured here and logged once at the end of the
+            # block (#57), on every path — success, network error, auth-fail.
+            poll_error     = None
+            poll_track_ids = []
+            poll_results   = []
+
             # Refresh access token when absent or near expiry
             if access_token is None or now_ms >= expires_at:
                 token, expires_in = spotify.refresh_token(
@@ -152,6 +158,7 @@ def main():
                     animator   = ErrorIndicator(ErrorIndicator.AUTH_FAIL)
                     error_mode = ErrorIndicator.AUTH_FAIL
                     poller.on_error(now_ms)
+                    poll_error = "auth_fail"
                 if _wdt:
                     _wdt.feed()   # token call may have consumed several seconds
 
@@ -160,6 +167,7 @@ def main():
                 if track_ids is None:
                     # Network or API error
                     poller.on_error(now_ms)
+                    poll_error = "network"
                     if _blip is None:
                         _blip = ApiErrorBlip(_last_colors)
                 else:
@@ -168,6 +176,10 @@ def main():
                     state.last_track_ids   = [tid for tid, _aid in track_ids]
                     state.last_poll_ms     = now_ms
                     state.last_mood_colors = new_colors
+                    poll_track_ids = state.last_track_ids
+                    # (v, e) per track, order-aligned to track_ids; None on miss.
+                    # OUTCOME_FIELDS = (track_id, artist_id, source, v, e).
+                    poll_results = [(o[3], o[4]) for o in state.engine.last_poll_outcomes()]
 
                     if poller.is_persistent_failure(now_ms):
                         # Graceful degradation — treat as idle, not an error
@@ -183,6 +195,12 @@ def main():
                             animator = MoodTransition(new_colors, new_colors)
                         elif isinstance(animator, MoodTransition):
                             animator.update_target(new_colors)
+
+            # Log this poll regardless of outcome (#57). colors_after is the
+            # engine's mood output (last_mood_colors), not the animator overlay.
+            mood_colors = state.last_mood_colors if state.last_mood_colors is not None else [(0, 0, 0)] * 3
+            state.record_poll(now_ms, poll_track_ids, poll_results, mood_colors,
+                              state.engine.snapshot()["confidence"], poll_error)
 
         # ── Auth-fail overlay: dismiss when done ──────────────────────────
         if (error_mode == ErrorIndicator.AUTH_FAIL

--- a/src/musical-mood-ring/main.py
+++ b/src/musical-mood-ring/main.py
@@ -63,6 +63,79 @@ _GC_INTERVAL           = 10       # call gc.collect() every N loop iterations
 _SETUP_GRACE_MS        = 300_000  # 5 min after boot: config endpoints open, then lock to read-only
 
 
+def run_poll_cycle(state, poller, access_token, expires_at, now_ms, wdt=None):
+    """Run one Spotify poll and record the outcome to the poll log (#57).
+
+    Refreshes the access token when due, fetches recently-played, pushes hits
+    through the engine, and appends exactly one poll-log record on every outcome
+    path — auth-fail, network error, and success alike.
+
+    Extracted from main()'s loop so the poll-and-record wiring is importable and
+    unit-testable on its own (main() only auto-runs under __main__). This
+    function deliberately touches no animation state: it returns what the caller
+    needs to drive the animator, and the caller owns that mapping.
+
+    Returns a dict:
+        access_token, expires_at — carried forward; refreshed when due
+        poll_error  — None | "auth_fail" | "network"
+        new_colors  — engine.update() output on success, else None
+    """
+    poll_error     = None
+    poll_track_ids = []
+    poll_results   = []
+    new_colors     = None
+
+    # Refresh access token when absent or near expiry
+    if access_token is None or now_ms >= expires_at:
+        token, expires_in = spotify.refresh_token(
+            config.SPOTIFY_CLIENT_ID,
+            config.SPOTIFY_CLIENT_SECRET,
+            config.SPOTIFY_REFRESH_TOKEN,
+        )
+        if token:
+            access_token = token
+            expires_at   = now_ms + (expires_in - 60) * 1000
+        else:
+            poller.on_error(now_ms)
+            poll_error = "auth_fail"
+        if wdt:
+            wdt.feed()   # token call may have consumed several seconds
+
+    if poll_error is None and access_token:
+        track_ids = spotify.recently_played(access_token)
+        if track_ids is None:
+            # Network or API error
+            poller.on_error(now_ms)
+            poll_error = "network"
+        else:
+            new_colors = state.engine.update(track_ids)
+            poller.on_success(now_ms)
+            poll_track_ids = [tid for tid, _aid in track_ids]
+            # (v, e) per track, order-aligned to track_ids; None on a full miss
+            # (no bundle hit) so the record matches the issue's "(v,e) or null"
+            # schema rather than storing a [null, null] pair.
+            # OUTCOME_FIELDS = (track_id, artist_id, source, v, e).
+            poll_results = [None if o[2] == "miss" else (o[3], o[4])
+                            for o in state.engine.last_poll_outcomes()]
+            state.last_track_ids   = poll_track_ids
+            state.last_poll_ms     = now_ms
+            state.last_mood_colors = new_colors
+
+    # Log this poll regardless of outcome (#57). colors_after is the engine's
+    # mood output (last_mood_colors) — None until the first successful poll, not
+    # the animator overlay.
+    state.record_poll(now_ms, poll_track_ids, poll_results,
+                      state.last_mood_colors,
+                      state.engine.snapshot()["confidence"], poll_error)
+
+    return {
+        "access_token": access_token,
+        "expires_at":   expires_at,
+        "poll_error":   poll_error,
+        "new_colors":   new_colors,
+    }
+
+
 def main():
     bundle = None
     try:
@@ -137,70 +210,37 @@ def main():
             in_idle    = True
 
         # ── Poll ──────────────────────────────────────────────────────────
+        # run_poll_cycle does the fetch + engine update + poll-log record (#57);
+        # here we map its outcome onto the animator. Token state is threaded
+        # back out so it survives across iterations.
         if error_mode is None and config.SPOTIFY_REFRESH_TOKEN and poller.should_poll(now_ms):
-            # Per-poll outcome captured here and logged once at the end of the
-            # block (#57), on every path — success, network error, auth-fail.
-            poll_error     = None
-            poll_track_ids = []
-            poll_results   = []
+            result       = run_poll_cycle(state, poller, access_token, expires_at, now_ms, _wdt)
+            access_token = result["access_token"]
+            expires_at   = result["expires_at"]
+            poll_error   = result["poll_error"]
 
-            # Refresh access token when absent or near expiry
-            if access_token is None or now_ms >= expires_at:
-                token, expires_in = spotify.refresh_token(
-                    config.SPOTIFY_CLIENT_ID,
-                    config.SPOTIFY_CLIENT_SECRET,
-                    config.SPOTIFY_REFRESH_TOKEN,
-                )
-                if token:
-                    access_token = token
-                    expires_at   = now_ms + (expires_in - 60) * 1000
+            if poll_error == "auth_fail":
+                animator   = ErrorIndicator(ErrorIndicator.AUTH_FAIL)
+                error_mode = ErrorIndicator.AUTH_FAIL
+            elif poll_error == "network":
+                if _blip is None:
+                    _blip = ApiErrorBlip(_last_colors)
+            else:
+                new_colors = result["new_colors"]
+                if poller.is_persistent_failure(now_ms):
+                    # Graceful degradation — treat as idle, not an error
+                    if not in_idle:
+                        animator = IdleSparkle()
+                        in_idle  = True
                 else:
-                    animator   = ErrorIndicator(ErrorIndicator.AUTH_FAIL)
-                    error_mode = ErrorIndicator.AUTH_FAIL
-                    poller.on_error(now_ms)
-                    poll_error = "auth_fail"
-                if _wdt:
-                    _wdt.feed()   # token call may have consumed several seconds
-
-            if access_token and error_mode is None:
-                track_ids = spotify.recently_played(access_token)
-                if track_ids is None:
-                    # Network or API error
-                    poller.on_error(now_ms)
-                    poll_error = "network"
-                    if _blip is None:
-                        _blip = ApiErrorBlip(_last_colors)
-                else:
-                    new_colors = state.engine.update(track_ids)
-                    poller.on_success(now_ms)
-                    state.last_track_ids   = [tid for tid, _aid in track_ids]
-                    state.last_poll_ms     = now_ms
-                    state.last_mood_colors = new_colors
-                    poll_track_ids = state.last_track_ids
-                    # (v, e) per track, order-aligned to track_ids; None on miss.
-                    # OUTCOME_FIELDS = (track_id, artist_id, source, v, e).
-                    poll_results = [(o[3], o[4]) for o in state.engine.last_poll_outcomes()]
-
-                    if poller.is_persistent_failure(now_ms):
-                        # Graceful degradation — treat as idle, not an error
-                        if not in_idle:
-                            animator = IdleSparkle()
-                            in_idle  = True
-                    else:
-                        was_idle = in_idle
-                        in_idle  = False
-                        if was_idle:
-                            animator = StartupFlare(new_colors)
-                        elif isinstance(animator, StartupFlare) and animator.done:
-                            animator = MoodTransition(new_colors, new_colors)
-                        elif isinstance(animator, MoodTransition):
-                            animator.update_target(new_colors)
-
-            # Log this poll regardless of outcome (#57). colors_after is the
-            # engine's mood output (last_mood_colors), not the animator overlay.
-            mood_colors = state.last_mood_colors if state.last_mood_colors is not None else [(0, 0, 0)] * 3
-            state.record_poll(now_ms, poll_track_ids, poll_results, mood_colors,
-                              state.engine.snapshot()["confidence"], poll_error)
+                    was_idle = in_idle
+                    in_idle  = False
+                    if was_idle:
+                        animator = StartupFlare(new_colors)
+                    elif isinstance(animator, StartupFlare) and animator.done:
+                        animator = MoodTransition(new_colors, new_colors)
+                    elif isinstance(animator, MoodTransition):
+                        animator.update_target(new_colors)
 
         # ── Auth-fail overlay: dismiss when done ──────────────────────────
         if (error_mode == ErrorIndicator.AUTH_FAIL
@@ -230,8 +270,12 @@ def main():
         _sleep_ms(FRAME_MS)
 
 
-try:
-    main()
-except Exception:
-    if _HW:
-        _machine.reset()
+# MicroPython auto-runs main.py as the top-level boot script (__name__ ==
+# "__main__"); guarding the call lets CPython unit tests `import main` to reach
+# run_poll_cycle() without launching the infinite loop.
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        if _HW:
+            _machine.reset()

--- a/src/musical-mood-ring/runtime_state.py
+++ b/src/musical-mood-ring/runtime_state.py
@@ -19,6 +19,14 @@
 
 from mood_engine import OUTCOME_FIELDS
 
+# Depth of the rolling poll log (#57). recently_played() returns ≤10 tracks, so
+# a record is ~350 B typical, ~580 B worst case (10 IDs + their (v,e) pairs).
+# 20 records covers the last hour at the default 3-minute cadence. The whole log
+# is a handful of KB of small dicts in RAM — well within the ESP32 budget; only
+# the transient JSON of a full /poll-log response approaches ~12 KB, which the
+# board serves without trouble.
+_POLL_LOG_SIZE = 20
+
 
 class RuntimeState:
     """Aggregate of mutable runtime state observable via HTTP.
@@ -47,6 +55,7 @@ class RuntimeState:
         self.last_poll_ms     = 0                # ticks_ms of last successful poll
         self.last_colors      = [(0, 0, 0)] * 3  # last colors written to pixels
         self.last_mood_colors = None             # last engine.update() return; None until first call
+        self.poll_log         = []               # rolling list of the last _POLL_LOG_SIZE poll records
 
     def snapshot(self):
         """JSON-serializable view of all runtime state.
@@ -72,3 +81,57 @@ class RuntimeState:
             "last_mood_colors":   ([list(c) for c in self.last_mood_colors]
                                    if self.last_mood_colors is not None else None),
         }
+
+    def record_poll(self, time_ms, track_ids, track_results, colors_after,
+                    confidence_after, error):
+        """Append one poll outcome to the rolling log (#57), capped at _POLL_LOG_SIZE.
+
+        Called once per poll from main.py on every outcome path — success,
+        network error, and auth-fail alike — so the log is a faithful trace of
+        what the device actually did, not just its successes.
+
+        The record is built fully-owned and json.dumps()-able: input sequences
+        are copied (a caller mutating them later can't corrupt a stored record)
+        and tuples are flattened to lists. Per the M10 learning, colors_after is
+        the engine's mood output, not the animator's last_colors overlay.
+
+            time_ms          — ticks_ms when the poll ran
+            track_ids        — [str, ...] polled (empty on auth/network failure)
+            track_results    — [(v, e) | None, ...], order-aligned to track_ids
+            colors_after     — 3 (r, g, b) engine mood colors after the poll
+            confidence_after — engine confidence scalar after the poll
+            error            — None | "network" | "auth_fail"
+        """
+        record = {
+            "time_ms":          time_ms,
+            "track_ids":        list(track_ids),
+            "track_results":    [list(r) if r is not None else None
+                                 for r in track_results],
+            "colors_after":     [list(c) for c in colors_after],
+            "confidence_after": confidence_after,
+            "error":            error,
+        }
+        self.poll_log.append(record)
+        if len(self.poll_log) > _POLL_LOG_SIZE:
+            self.poll_log.pop(0)   # evict oldest; plain list keeps MicroPython happy
+
+    def poll_log_snapshot(self):
+        """JSON-serializable copy of the poll log, oldest first.
+
+        Each record is rebuilt with fresh nested lists so a reader can't mutate
+        the live log — the same deep-copy-to-JSON-ready discipline snapshot()
+        applies to last_colors. Kept separate from snapshot() so /state stays
+        lean and #58's /poll-log endpoint serves this buffer on its own.
+        """
+        return [
+            {
+                "time_ms":          r["time_ms"],
+                "track_ids":        list(r["track_ids"]),
+                "track_results":    [list(x) if x is not None else None
+                                     for x in r["track_results"]],
+                "colors_after":     [list(c) for c in r["colors_after"]],
+                "confidence_after": r["confidence_after"],
+                "error":            r["error"],
+            }
+            for r in self.poll_log
+        ]

--- a/src/musical-mood-ring/runtime_state.py
+++ b/src/musical-mood-ring/runtime_state.py
@@ -98,7 +98,11 @@ class RuntimeState:
             time_ms          — ticks_ms when the poll ran
             track_ids        — [str, ...] polled (empty on auth/network failure)
             track_results    — [(v, e) | None, ...], order-aligned to track_ids
-            colors_after     — 3 (r, g, b) engine mood colors after the poll
+            colors_after     — 3 (r, g, b) engine mood colors, or None before the
+                               first successful poll. Stored as None rather than
+                               black so a reader can tell "engine never produced a
+                               mood" apart from a genuine all-black output — the
+                               same distinction snapshot() preserves.
             confidence_after — engine confidence scalar after the poll
             error            — None | "network" | "auth_fail"
         """
@@ -107,7 +111,8 @@ class RuntimeState:
             "track_ids":        list(track_ids),
             "track_results":    [list(r) if r is not None else None
                                  for r in track_results],
-            "colors_after":     [list(c) for c in colors_after],
+            "colors_after":     ([list(c) for c in colors_after]
+                                 if colors_after is not None else None),
             "confidence_after": confidence_after,
             "error":            error,
         }
@@ -129,7 +134,8 @@ class RuntimeState:
                 "track_ids":        list(r["track_ids"]),
                 "track_results":    [list(x) if x is not None else None
                                      for x in r["track_results"]],
-                "colors_after":     [list(c) for c in r["colors_after"]],
+                "colors_after":     ([list(c) for c in r["colors_after"]]
+                                     if r["colors_after"] is not None else None),
                 "confidence_after": r["confidence_after"],
                 "error":            r["error"],
             }

--- a/tests/unit/test_main_poll_cycle.py
+++ b/tests/unit/test_main_poll_cycle.py
@@ -1,0 +1,132 @@
+"""
+Unit tests for main.run_poll_cycle — the poll-and-record wiring extracted from
+main()'s loop so it can be tested without launching the infinite animation loop.
+
+These lock down the glue the runtime_state tests can't reach: which error string
+each outcome path emits, the once-per-poll record guarantee, the field sourcing
+(track_ids / (v,e) outcomes / last_mood_colors), and the I1 None-colors fix.
+"""
+import json
+
+import pytest
+
+import miss_log
+import spotify
+import main
+from conftest import build_bundle
+from mmar          import MMARBundle
+from mood_engine   import MoodEngine
+from poller        import Poller
+from runtime_state import RuntimeState
+
+
+@pytest.fixture(autouse=True)
+def _redirect_miss_log(tmp_path, monkeypatch):
+    """Keep miss_log writes out of the working directory during tests."""
+    monkeypatch.setattr(miss_log, "_PATH", str(tmp_path / "misses.txt"))
+
+
+def _state():
+    """RuntimeState with an engine that knows track 't1' and nothing else."""
+    s = RuntimeState()
+    s.engine = MoodEngine(MMARBundle(build_bundle(("t1", 0.3, 0.7))))
+    return s
+
+
+_VALID_TOKEN = ("tok", 3600)   # (access_token, expires_in)
+_FAR_FUTURE  = 10 ** 12        # expires_at well beyond now_ms → no refresh
+
+
+# ── Importability (the whole reason for the __main__ guard) ─────────────────
+
+def test_importing_main_does_not_run_the_loop():
+    """`import main` must not launch main(); both entry points are exposed."""
+    assert hasattr(main, "run_poll_cycle")
+    assert callable(main.run_poll_cycle)
+    assert callable(main.main)
+
+
+# ── One record per call, on every outcome path ──────────────────────────────
+
+def test_auth_fail_records_one_auth_fail_record(monkeypatch):
+    monkeypatch.setattr(spotify, "refresh_token", lambda *a: (None, 0))
+    state, poller = _state(), Poller()
+
+    res = main.run_poll_cycle(state, poller, access_token=None, expires_at=0, now_ms=1000)
+
+    assert res["poll_error"] == "auth_fail"
+    assert len(state.poll_log) == 1
+    rec = state.poll_log[-1]
+    assert rec["error"]         == "auth_fail"
+    assert rec["track_ids"]     == []
+    assert rec["track_results"] == []
+
+
+def test_network_error_records_one_network_record(monkeypatch):
+    monkeypatch.setattr(spotify, "refresh_token", lambda *a: _VALID_TOKEN)
+    monkeypatch.setattr(spotify, "recently_played", lambda _t: None)
+    state, poller = _state(), Poller()
+
+    res = main.run_poll_cycle(state, poller, access_token=None, expires_at=0, now_ms=1000)
+
+    assert res["poll_error"] == "network"
+    assert len(state.poll_log) == 1
+    rec = state.poll_log[-1]
+    assert rec["error"]     == "network"
+    assert rec["track_ids"] == []
+
+
+def test_success_records_tracks_and_results(monkeypatch):
+    # Token still valid → no refresh; t1 is a hit, "miss" is not in the bundle.
+    monkeypatch.setattr(spotify, "recently_played",
+                        lambda _t: [("t1", "a1"), ("miss", "a2")])
+    state, poller = _state(), Poller()
+
+    res = main.run_poll_cycle(state, poller, access_token="tok",
+                              expires_at=_FAR_FUTURE, now_ms=1000)
+
+    assert res["poll_error"] is None
+    assert res["new_colors"] is not None
+    assert len(state.poll_log) == 1
+    rec = state.poll_log[-1]
+    assert rec["error"]     is None
+    assert rec["track_ids"] == ["t1", "miss"]
+    # Order-aligned to track_ids: t1 → (v, e) pair, miss → null.
+    assert rec["track_results"][0] is not None and len(rec["track_results"][0]) == 2
+    assert rec["track_results"][1] is None
+    # last_mood_colors was set, so colors_after is a real 3-pixel list.
+    assert rec["colors_after"] is not None and len(rec["colors_after"]) == 3
+
+
+def test_each_call_appends_exactly_one_record(monkeypatch):
+    monkeypatch.setattr(spotify, "recently_played", lambda _t: [("t1", "a1")])
+    state, poller = _state(), Poller()
+    for i in range(3):
+        main.run_poll_cycle(state, poller, "tok", _FAR_FUTURE, now_ms=1000 + i)
+    assert len(state.poll_log) == 3
+
+
+# ── I1: colors_after is None before the first successful poll, not black ─────
+
+def test_auth_fail_before_any_success_records_none_colors(monkeypatch):
+    monkeypatch.setattr(spotify, "refresh_token", lambda *a: (None, 0))
+    state, poller = _state(), Poller()
+
+    main.run_poll_cycle(state, poller, access_token=None, expires_at=0, now_ms=1000)
+
+    rec = state.poll_log[-1]
+    assert rec["colors_after"] is None            # NOT [[0,0,0],[0,0,0],[0,0,0]]
+    assert json.loads(json.dumps(rec)) == rec     # still json-serializable
+
+
+# ── Token state threads back out ────────────────────────────────────────────
+
+def test_refresh_updates_token_and_expiry(monkeypatch):
+    monkeypatch.setattr(spotify, "refresh_token", lambda *a: ("fresh", 3600))
+    monkeypatch.setattr(spotify, "recently_played", lambda _t: [("t1", "a1")])
+    state, poller = _state(), Poller()
+
+    res = main.run_poll_cycle(state, poller, access_token=None, expires_at=0, now_ms=1000)
+
+    assert res["access_token"] == "fresh"
+    assert res["expires_at"]   == 1000 + (3600 - 60) * 1000

--- a/tests/unit/test_runtime_state.py
+++ b/tests/unit/test_runtime_state.py
@@ -235,6 +235,17 @@ def test_poll_log_snapshot_returns_copies():
     assert state.poll_log[0]["track_ids"] == ["t0"]
 
 
+def test_poll_record_colors_after_none_preserved():
+    """A poll that fails before any success has no mood yet — store None, not
+    black, so /poll-log keeps the same distinction snapshot() does."""
+    state = RuntimeState()
+    state.record_poll(time_ms=1, track_ids=[], track_results=[],
+                      colors_after=None, confidence_after=1.0, error="auth_fail")
+    rec = state.poll_log_snapshot()[0]
+    assert rec["colors_after"] is None
+    assert json.loads(json.dumps(rec)) == rec   # None survives json round-trip
+
+
 def test_record_poll_copies_inputs_not_aliases():
     """A caller mutating the lists it passed in must not change a stored record."""
     state = RuntimeState()

--- a/tests/unit/test_runtime_state.py
+++ b/tests/unit/test_runtime_state.py
@@ -136,3 +136,115 @@ def test_no_circular_import_runtime_first():
 
 def test_no_circular_import_config_server_first():
     _reimport("config_server", "mood_engine", "runtime_state")
+
+
+# ── Poll ring buffer (#57) ──────────────────────────────────────────────────
+#
+# A rolling log of the last RuntimeState._POLL_LOG_SIZE poll outcomes, appended
+# once per poll on every path (success, network error, auth-fail). Bounded
+# memory; each record json.dumps()-able. Feeds #58's /poll-log endpoint.
+
+from runtime_state import _POLL_LOG_SIZE
+
+
+def _record(state, n, error=None):
+    """Append one synthetic poll record numbered n."""
+    state.record_poll(
+        time_ms=n * 1000,
+        track_ids=["t%d" % n],
+        track_results=[(0.3, 0.7)],
+        colors_after=[(10, 20, 30), (40, 50, 60), (70, 80, 90)],
+        confidence_after=1.0,
+        error=error,
+    )
+
+
+def test_poll_log_starts_empty():
+    state = RuntimeState()
+    assert state.poll_log == []
+    assert state.poll_log_snapshot() == []
+
+
+def test_poll_log_caps_at_size_after_30_polls():
+    """Required by the issue: 30 polls, only the most recent 20 retained."""
+    state = RuntimeState()
+    for n in range(30):
+        _record(state, n)
+    log = state.poll_log_snapshot()
+    assert len(log) == _POLL_LOG_SIZE == 20
+    # Oldest-first; the first 10 (0–9) have been evicted, 10–29 remain.
+    assert [r["time_ms"] for r in log] == [n * 1000 for n in range(10, 30)]
+
+
+def test_poll_log_no_growth_over_100_plus_cycles():
+    state = RuntimeState()
+    for n in range(150):
+        _record(state, n)
+    assert len(state.poll_log) == _POLL_LOG_SIZE
+    assert len(state.poll_log_snapshot()) == _POLL_LOG_SIZE
+
+
+def test_poll_record_shape_and_fields():
+    state = RuntimeState()
+    state.record_poll(
+        time_ms=12345,
+        track_ids=["a", "b"],
+        track_results=[(0.1, 0.2), None],
+        colors_after=[(1, 2, 3), (4, 5, 6), (7, 8, 9)],
+        confidence_after=0.6,
+        error=None,
+    )
+    rec = state.poll_log_snapshot()[0]
+    assert rec == {
+        "time_ms":          12345,
+        "track_ids":        ["a", "b"],
+        "track_results":    [[0.1, 0.2], None],   # miss → null; tuples → lists
+        "colors_after":     [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+        "confidence_after": 0.6,
+        "error":            None,
+    }
+
+
+def test_poll_record_json_dumps_able():
+    state = RuntimeState()
+    _record(state, 0)
+    _record(state, 1, error="auth_fail")
+    snap = state.poll_log_snapshot()
+    assert json.loads(json.dumps(snap)) == snap
+
+
+@pytest.mark.parametrize("error", [None, "auth_fail", "network"])
+def test_poll_log_records_every_outcome_path(error):
+    """Append happens regardless of whether error_mode is None or set."""
+    state = RuntimeState()
+    state.record_poll(
+        time_ms=1, track_ids=[], track_results=[],
+        colors_after=[(0, 0, 0)] * 3, confidence_after=1.0, error=error,
+    )
+    assert state.poll_log_snapshot()[0]["error"] == error
+
+
+def test_poll_log_snapshot_returns_copies():
+    """Mutating the snapshot must not corrupt the live log."""
+    state = RuntimeState()
+    _record(state, 0)
+    snap = state.poll_log_snapshot()
+    snap[0]["error"] = "tampered"
+    snap[0]["track_ids"].append("x")
+    assert state.poll_log[0]["error"] is None
+    assert state.poll_log[0]["track_ids"] == ["t0"]
+
+
+def test_record_poll_copies_inputs_not_aliases():
+    """A caller mutating the lists it passed in must not change a stored record."""
+    state = RuntimeState()
+    ids = ["t0"]
+    results = [(0.3, 0.7)]
+    colors = [(1, 2, 3), (4, 5, 6), (7, 8, 9)]
+    state.record_poll(time_ms=0, track_ids=ids, track_results=results,
+                      colors_after=colors, confidence_after=1.0, error=None)
+    ids.append("mutated")
+    results.append((9.9, 9.9))
+    rec = state.poll_log[0]
+    assert rec["track_ids"] == ["t0"]
+    assert rec["track_results"] == [[0.3, 0.7]]


### PR DESCRIPTION
Closes #57

## Summary

Adds a rolling **20-entry poll log** to `RuntimeState` — the shared state object from #56 — so the device can show what it actually polled when colors look wrong. This is the diagnostic foundation for #58's `/poll-log` endpoint (the endpoint itself is out of scope here).

- `runtime_state.py`
  - `record_poll(time_ms, track_ids, track_results, colors_after, confidence_after, error)` — builds a fully-owned, `json.dumps()`-able record and appends it; `append` + `pop(0)` caps the list at `_POLL_LOG_SIZE = 20` (no `collections.deque`, so it runs identically on MicroPython and CPython). Inputs are copied so a later caller mutation can't corrupt a stored record.
  - `poll_log_snapshot()` — deep-copies records to JSON-ready form (same discipline `snapshot()` uses for `last_colors`). Kept **separate** from `snapshot()` so `/state` stays lean and `/poll-log` serves this buffer on its own.
  - `colors_after` stores the engine's **mood** output (`last_mood_colors`), not the animator overlay (`last_colors`) — per the M10 learning that those differ.
- `main.py` — the poll gate now captures one outcome per poll and calls `record_poll` once on **every** path: `error="auth_fail"` (token refresh failed), `error="network"` (`recently_played` → `None`), or `error=None` with track IDs + order-aligned `(v,e)`/`null` results on success.

## Notes / accepted deviation

The issue targets "~500 B/record, ≤10 KB total." That holds in **RAM** (20 small dicts — negligible on the ESP32). Worst case (10 tracks every poll) a *serialized* record is 581 B and the full response ~11.6 KB; that string only materializes transiently when `/poll-log` is hit, and the board serves it fine. Accepted as-is; captured as a learning so #58's handler can stream/chunk or add `?n=` if RAM is tight at request time.

## Test plan

`pytest tests/unit/` → **301 passing**. New `test_runtime_state.py` coverage:
- 30 polls → only the most recent 20 retained (required size-cap test)
- 150 polls → still 20 (no memory growth over 100+ cycles)
- record shape/fields exact; misses serialize as `null`; tuples → lists
- records on `error` ∈ {`None`, `auth_fail`, `network`}
- `poll_log_snapshot()` round-trips through JSON and returns copies (mutation can't corrupt the live log)
- `record_poll` copies its inputs (caller mutation can't corrupt a stored record)

🤖 Generated with [Claude Code](https://claude.com/claude-code)